### PR TITLE
Add Homebrew support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ output.
 
 ## Install on Mac via Homebrew
 
-    $ brew tap bbcrd/audiowaveform
+    $ brew tap bbcrd/audiowaveform https://github.com/bbcrd/audiowaveform
     $ brew install audiowaveform
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ samples (where *N* is controlled by the `--zoom` command-line option), such that
 each *N* input samples produces one pair of minimum and maxmimum points in the
 output.
 
+## Install on Mac via Homebrew
+
+    $ brew tap bbcrd/audiowaveform
+    $ brew install audiowaveform
+
 ## Getting started
 
 **audiowaveform** requires [cmake](http:///www.cmake.org) 2.8.7 or later, g++
@@ -26,6 +31,8 @@ output.
 The software has been developed on Ubuntu 12.04 and Fedora 18. Due to compiler
 and library version requirements, the software may not build on earlier
 operating system releases.
+
+## Build manually
 
 ### Install package dependencies
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ output.
 
 ## Install on Mac via Homebrew
 
-    $ brew tap bbcrd/audiowaveform https://github.com/bbcrd/audiowaveform
+    $ brew tap bbcrd/audiowaveform
     $ brew install audiowaveform
 
 ## Getting started

--- a/audiowaveform.rb
+++ b/audiowaveform.rb
@@ -1,0 +1,34 @@
+require 'formula'
+
+class Audiowaveform < Formula
+	desc "C++ program to generate waveform data and render waveform images from audio files"
+	homepage "https://github.com/bbcrd/audiowaveform"
+	url "https://github.com/bbcrd/audiowaveform/archive/1.0.10.tar.gz"
+	version '1.0.10'
+	sha256 "a33aa5e922cc61e0953d681178f2ac36536c7f98e962b86ee8285045f05b02b6"
+
+	depends_on "cmake" 
+	depends_on "libmad"
+	depends_on "libsndfile"
+	depends_on "gd"
+	depends_on "boost" => "with-c++11"
+	# depends_on "gmock"
+
+	def install
+		# ENV.deparallelize
+		cmake_args = std_cmake_parameters.split
+		cmake_args << "-D ENABLE_TESTS=0"
+		cmake_args << "-D CMAKE_C_COMPILER=/usr/bin/clang"
+		cmake_args << "-D CMAKE_CXX_COMPILER=/usr/bin/clang++"
+		cmake_args << "-D CMAKE_INSTALL_PREFIX=#{prefix}"
+
+		mkdir "build" do
+			system "cmake", "..", *cmake_args
+			system "make", "install"
+		end
+	end
+
+	test do
+		# system "make", "test"
+	end
+end

--- a/audiowaveform.rb
+++ b/audiowaveform.rb
@@ -20,10 +20,10 @@ class Audiowaveform < Formula
 	def install
 		# ENV.deparallelize
 		cmake_args = std_cmake_parameters.split
-		cmake_args << "-D ENABLE_TESTS=0"
-		cmake_args << "-D CMAKE_C_COMPILER=/usr/bin/clang"
-		cmake_args << "-D CMAKE_CXX_COMPILER=/usr/bin/clang++"
-		cmake_args << "-D CMAKE_INSTALL_PREFIX=#{prefix}"
+		cmake_args << "-DENABLE_TESTS=0"
+		cmake_args << "-DCMAKE_C_COMPILER=/usr/bin/clang"
+		cmake_args << "-DCMAKE_CXX_COMPILER=/usr/bin/clang++"
+		cmake_args << "-DCMAKE_INSTALL_PREFIX=#{prefix}"
 
 		mkdir "build" do
 			system "cmake", "..", *cmake_args

--- a/audiowaveform.rb
+++ b/audiowaveform.rb
@@ -4,7 +4,6 @@ class Audiowaveform < Formula
 	desc "C++ program to generate waveform data and render waveform images from audio files"
 	homepage "https://github.com/bbcrd/audiowaveform"
 	url "https://github.com/bbcrd/audiowaveform/archive/1.0.10.tar.gz"
-	version '1.0.10'
 	sha256 "a33aa5e922cc61e0953d681178f2ac36536c7f98e962b86ee8285045f05b02b6"
 
 	depends_on "cmake" 

--- a/audiowaveform.rb
+++ b/audiowaveform.rb
@@ -10,7 +10,11 @@ class Audiowaveform < Formula
 	depends_on "libmad"
 	depends_on "libsndfile"
 	depends_on "gd"
-	depends_on "boost" => "with-c++11"
+	if MacOS.version < :mavericks
+		depends_on "boost" => "c++11"
+	else
+		depends_on "boost"
+	end
 	# depends_on "gmock"
 
 	def install

--- a/audiowaveform.rb
+++ b/audiowaveform.rb
@@ -4,7 +4,7 @@ class Audiowaveform < Formula
 	desc "C++ program to generate waveform data and render waveform images from audio files"
 	homepage "https://github.com/bbcrd/audiowaveform"
 	url "https://github.com/bbcrd/audiowaveform/archive/1.0.10.tar.gz"
-	sha256 "a33aa5e922cc61e0953d681178f2ac36536c7f98e962b86ee8285045f05b02b6"
+	sha256 "7d76a65962ec147befaad807aeae893a0d6f7f8443f9a5ecfe4776cbfc8cff37"
 
 	depends_on "cmake" 
 	depends_on "libmad"

--- a/audiowaveform.rb
+++ b/audiowaveform.rb
@@ -18,7 +18,6 @@ class Audiowaveform < Formula
 	# depends_on "gmock"
 
 	def install
-		# ENV.deparallelize
 		cmake_args = std_cmake_parameters.split
 		cmake_args << "-DENABLE_TESTS=0"
 		cmake_args << "-DCMAKE_C_COMPILER=/usr/bin/clang"


### PR DESCRIPTION
I added a homebrew tap formula. This makes installation on Mac a lot easier. I also added the installation instructions to the Readme.

I will be as easy as this:

    $ brew tap bbcrd/audiowaveform https://github.com/bbcrd/audiowaveform
    $ brew install audiowaveform

If you release a new version you will only have to change `url` and `sha256` in `audiowaveform.rb`

```ruby
	url "https://github.com/bbcrd/audiowaveform/archive/1.0.10.tar.gz"
	sha256 "7d76a65962ec147befaad807aeae893a0d6f7f8443f9a5ecfe4776cbfc8cff37"
```

As long as this PR is not merged into master adding the tap like described in the Readme will not work.

If you want to test you have to use the repo link of this PR:

```bash
brew tap funkenstrahlen/audiowaveform https://github.com/funkenstrahlen/audiowaveform
brew install audiowaveform
```